### PR TITLE
Added automatic home page banner update (Solving Issue 42)

### DIFF
--- a/_includes/important.html
+++ b/_includes/important.html
@@ -1,6 +1,8 @@
 <div id="important">
 	<h6 style="text-align: center;">Thank you for making our first year possible!</h6>
 <p>
+	{% for event in site.events limit:1 %}
+	  Latest event: {{event.title}} on {{event.event_date}}
+	{% endfor %}
 </p>
-
 </div>

--- a/_includes/important.html
+++ b/_includes/important.html
@@ -2,7 +2,7 @@
 	<h6 style="text-align: center;">Thank you for making our first year possible!</h6>
 <p>
 	{% for event in site.events limit:1 %}
-	  Latest event: {{event.title}} on {{event.event_date}}
+	  Latest event: <a href = "{{event.url}}">{{event.title}}</a> on {{event.event_date}}
 	{% endfor %}
 </p>
 </div>


### PR DESCRIPTION
Added some of the features from [Issue 42](https://github.com/BUGS-NYU/bugs-nyu.github.io/issues/42).

I wasn't able to do a small description on the banner, or the location.
I'm not sure how to solve those issues, I think we would have to add those variables within ```events``` 

I added a link to the latest event within giving the title, and date. 