### PR TITLE
small Banner update: Remove old, Cover edge case

### DIFF
--- a/_includes/important.html
+++ b/_includes/important.html
@@ -1,7 +1,7 @@
 <div id="important">
 <p>
 	{% assign final_title = "0" %}
-	{% assign today = "now" | date: "%s" %} <!-- The easiest way to compare dates numerically is to convert the date to a hard unix timestamp -->
+	{% assign today = "now" | date: "%Y-%m-%d" | date: "%s" %} <!-- The easiest way to compare dates numerically is to convert the date to a hard unix timestamp -->
 
 	{% for event in site.events %}
 		{% assign event_date = event.event_date | date: "%s" %} <!-- Unix timestamp for comparing dates -->

--- a/_includes/important.html
+++ b/_includes/important.html
@@ -1,6 +1,4 @@
 <div id="important">
-
-<h6 style="text-align: center;">Thank you for making our first year possible</h6>
 <p>
 	{% assign final_title = "0" %}
 	{% assign today = "now" | date: "%s" %} <!-- The easiest way to compare dates numerically is to convert the date to a hard unix timestamp -->


### PR DESCRIPTION
- Removes the old "thank you..." message, covers issue #53 
- Removes time from today's date for comparing with event dates. This covers the edge case where the next upcoming event is today and allows it to still be displayed on the banner.