### PR TITLE
covers Banner for events on current day

### DIFF
--- a/_includes/important.html
+++ b/_includes/important.html
@@ -1,8 +1,7 @@
 <div id="important">
-	<h6 style="text-align: center;">We miss Nadira and David!</h6>
 <p>
 	{% assign final_title = "0" %}
-	{% assign today = "now" | date: "%s" %} <!-- The easiest way to compare dates numerically is to convert the date to a hard unix timestamp -->
+	{% assign today = "now" | date: "%Y-%m-%d" | date: "%s" %} <!-- The easiest way to compare dates numerically is to convert the date to a hard unix timestamp -->
 
 	{% for event in site.events %}
 		{% assign event_date = event.event_date | date: "%s" %} <!-- Unix timestamp for comparing dates -->


### PR DESCRIPTION
Removes time from today's date for comparing with event dates. This covers the edge case where the next upcoming event is today and allows it to still be displayed on the banner.