### PR TITLE
Minor changes to important.html

### DIFF
--- a/_events/template_event.md
+++ b/_events/template_event.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 title: "Template Event"
-event_date: 2017-12-31
+date: 2017-12-31
 time: "8pm"
 location: "Courant Room 205"
 ---

--- a/_includes/important-format.html
+++ b/_includes/important-format.html
@@ -1,0 +1,2 @@
+{% assign event = include.event %}
+Upcoming: <a href="{{ event.url }}">{{ event.title }}</a> on {{ event.date | date: "%B %e, %Y" }} in {{ event.location }} at {{ event.time }}

--- a/_includes/important.html
+++ b/_includes/important.html
@@ -1,33 +1,28 @@
+<!-- Set the value for today to today's date -->
+{% assign today = "now" | date: "%Y-%m-%d" | date: "%s" %}
+
+{% for event in site.events %}
+	<!-- variable date holds date of current event in seconds -->
+	{% assign date = event.date | date: "%s" %}
+
+	<!-- If the event's in the past, ignore it -->
+	{% if date < today %}{% continue %}{% endif %}
+
+	<!-- The code inside this 'unless' block only executes if the expression is false -->
+	{% unless date > final_date %}<!-- This evaluates to false if final_date isn't assigned yet -->
+		<!-- Assigns final_event and final_date to keep track of the
+			date of the most imminent future event -->
+		{% assign final_event = event %}
+		{% assign final_date = date %}
+	{% endunless %}
+{% endfor %}
+
 <div id="important">
-<p>
-	{% assign final_title = "0" %}
-	{% assign today = "now" | date: "%Y-%m-%d" | date: "%s" %} <!-- The easiest way to compare dates numerically is to convert the date to a hard unix timestamp -->
-
-	{% for event in site.events %}
-		{% assign event_date = event.event_date | date: "%s" %} <!-- Unix timestamp for comparing dates -->
-		{% if event_date >= today %} <!-- Filter out past events -->
-			{% if final_title == "0" %} <!-- Make variable assignments for first future event encountered -->
-				{% assign final_title = event.title %}
-				{% assign final_date = event.event_date %}
-				{% assign final_location = event.location %}
-				{% assign final_time = event.time %}
-				{% assign final_date_compare = event_date_compare %} <!-- Unix timestamp for comparing dates -->
-			{% elsif event_date < final_date_compare %} <!-- If there is a sooner future event, aka the next upcoming event, reassign all relevant variables -->
-				{% assign final_title = event.title %}
-				{% assign final_date = event.event_date %}
-				{% assign final_location = event.location %}
-				{% assign final_time = event.time %}
-				{% assign final_date_compare = event_date_compare %}
-			{% endif %}
+	<p>
+		{% if final_event %}
+			{% include important-format.html event = final_event %}
+		{% else %}
+			No events upcoming, keep being awesome!
 		{% endif %}
-	{% endfor %}
-
-	{% if final_title != "0" %}
-		Upcoming: {{ final_title }} on {{ final_date | date: "%B %e, %Y" }} in {{ final_location }} at {{ final_time }} <!-- Try to have all variables complete in event MD files so it looks nice :) -->
-	{% else %}
-		No events upcoming, keep being awesome!
-	{% endif %}
-
-	<!-- Not sure how to make the event URL a variable because it's a special case not written in the event MD files -->
-</p>
+	</p>
 </div>


### PR DESCRIPTION
List of changes:
- **Using `event.date`** - replaced `event.event_date` with the built-in value `event.date`
- **Separation of parts** - Moved visual logic to its own include. Probably not a big deal, but it might be useful if we try to make the important header bar more flexible in the future
- **Rewriting logic** - Replaced the large if-else statement with a single unless statement that has only 2 assignments (as opposed to 4 in each block)
- **Implemented `event.url`** - Made the name of the event link to the event's permanent URL using `event.url`