### PR TITLE
[WIP] Adding BUGS logo to pages

### DIFF
--- a/_debug/typography.md
+++ b/_debug/typography.md
@@ -3,7 +3,6 @@ layout: debug
 ---
 #### Logo
 
-
 <div class="bugs-logo">
   <div class="bugs-logo-left-antennae">\</div>
   <div class="bugs-logo-right-antennae">/</div>

--- a/_includes/logo.html
+++ b/_includes/logo.html
@@ -1,0 +1,10 @@
+<div class="bugs-logo" style="{{ include.style }}">
+  <div class="bugs-logo-left-antennae">\</div>
+  <div class="bugs-logo-right-antennae">/</div>
+  <div class="bugs-logo-left-wing">&lt;</div>
+  <div class="bugs-logo-left-body">{</div>
+  <div class="bugs-logo-middle-body">(((()</div>
+  <div class="bugs-logo-right-body">}</div>
+  <div class="bugs-logo-right-wing">&gt;</div>
+</div>
+

--- a/_sass/_logo.scss
+++ b/_sass/_logo.scss
@@ -10,18 +10,23 @@
       </div>
 */
 
+#logo-test {
+  font-size: 3rem;
+}
+
 .bugs-logo {
 
-  width: 6rem;
-  height: 6rem;
+  width: 6em;
+  height: 6em;
   color: $nyu-purple;
   border: 1px solid black;
-  transform: translate(10rem);
+  // transform: translate(10rem) rotate(-45deg);
 
   > div {
     width: 0;
     height: 0;
     float: left;
+    // transform: rotate(90deg);
   }
 
   > .bugs-logo-left-antennae,> .bugs-logo-right-antennae,
@@ -30,15 +35,15 @@
   }
 
   > .bugs-logo-middle-body {
-    transform: translate(2.5em, .75em) rotate(90deg);
+    transform: translate(2.5em, 1em) rotate(90deg);
   }
 
   > .bugs-logo-left-antennae {
-    transform: translate(1em, -.375em);
+    transform: translate(1em, -.125em);
   }
 
   > .bugs-logo-right-antennae {
-    transform: translate(1.875em, -.375em);
+    transform: translate(1.95em, -.125em);
   }
 
   > .bugs-logo-right-body,> .bugs-logo-left-body
@@ -47,11 +52,11 @@
   }
 
   > .bugs-logo-left-body {
-    transform: translate(.5625em, .325em);
+    transform: translate(.5625em, .500em);
   }
 
   > .bugs-logo-right-body {
-    transform: translate(1.5625em, .325em);
+    transform: translate(1.58em, .500em);
   }
 
   > .bugs-logo-right-wing,> .bugs-logo-left-wing {
@@ -59,10 +64,10 @@
   }
 
   > .bugs-logo-left-wing {
-    transform: translate(.625em, .875em);
+    transform: translate(.625em, 1.125em);
   }
 
   > .bugs-logo-right-wing {
-    transform: translate(3.1875em, .875em);
+    transform: translate(3.25em, 1.125em);
   }
 }


### PR DESCRIPTION
**PR Type:** New Feature
**Related #'s:** #142 

Adding the Logo back to the main pages of the website. Not done.

## Description
Our logo isn't visible anywhere on the website right now. I'd like to fix that by adding large versions of it to the top and bottom of each page.

#### Checklist
- [x] Add support for Logo as HTML include with supporting CSS
- [ ] Refactor website with a `page.title` field in the `base` layout to make adding logo to header easier
- [ ] Add logo to "Contact Us" section
- [ ] Add logo to header
- [ ] add logo to center of `team.html` page

## Checklist:
- [x] My code follows the [code style of this project][code-style]
- [x] I have read the [**CONTRIBUTING** document][contributing]

[contributing]: https://github.com/BUGS-NYU/bugs-nyu.github.io/blob/master/.github/CONTRIBUTING.md
[code-style]: https://github.com/BUGS-NYU/bugs-nyu.github.io/tree/master/docs/STYLE_GUIDE.md
