### PR TITLE
Facebook link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,13 +4,13 @@ description: >-
   NYU BUGS is the open source club at NYU. We promote open source by engaging students
   through collaborative projects, hosting industry professions, and running open
   source workshops.
-url: "https://bugs-nyu.github.io"
+url: "https://yuchenliu15.github.io"
 repository_url: https://github.com/BUGS-NYU/bugs-nyu.github.io
 org_url: https://github.com/BUGS-NYU/
 markdown: kramdown
 
 # Edit this if you'd like to check out the site on your own fork
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "http://yuchenliu.me/bugs-nyu.github.io/" # the subpath of your site, e.g. /blog
 calendar_embed:
   xs: "https://calendar.google.com/calendar/embed?height=400&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0&amp;showNav=0&amp;mode=AGENDA"
   sm: "https://calendar.google.com/calendar/embed?height=500&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0&amp;showNav=0&amp;mode=AGENDA"

--- a/_config.yml
+++ b/_config.yml
@@ -4,13 +4,13 @@ description: >-
   NYU BUGS is the open source club at NYU. We promote open source by engaging students
   through collaborative projects, hosting industry professions, and running open
   source workshops.
-url: "https://yuchenliu15.github.io"
+url: "https://bugs-nyu.github.io"
 repository_url: https://github.com/BUGS-NYU/bugs-nyu.github.io
 org_url: https://github.com/BUGS-NYU/
 markdown: kramdown
 
 # Edit this if you'd like to check out the site on your own fork
-baseurl: "http://yuchenliu.me/bugs-nyu.github.io/" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 calendar_embed:
   xs: "https://calendar.google.com/calendar/embed?height=400&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0&amp;showNav=0&amp;mode=AGENDA"
   sm: "https://calendar.google.com/calendar/embed?height=500&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0&amp;showNav=0&amp;mode=AGENDA"

--- a/_contributors/yliu.md
+++ b/_contributors/yliu.md
@@ -1,0 +1,6 @@
+---
+name: Yuchen Liu
+type: member
+---
+I'm a freshman studying CS and Data Science.
+I'm new to open source!

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -1,27 +1,28 @@
 <div class="row justify-content-center">
-<div class="col-xs-12 col-sm-10 col-md-8">
+  <div class="col-xs-12 col-sm-10 col-md-8">
 
-  <div class="row align-content-center main-page-element">
+    <div class="row align-content-center main-page-element">
 
-    <div class="col-12 col-lg-4">
-      <div class="gutter-padding">
-      <h3>
-        Contact Us
-      </h3>
+      <div class="col-12 col-lg-4">
+        <div class="gutter-padding">
+          <h3>
+            Contact Us
+          </h3>
+        </div>
+      </div>
+
+      <div class="col-12 col-lg-6">
+        <div class="gutter-padding">
+          <p>
+            Send us an <a href="mailto:bugscommunicationsteam@gmail.com">Email</a>,
+            like our <a href="https://www.facebook.com/BUGS-NYUs-Open-Source-Club-105472827550489">Facebook page</a>, or
+            subscribe
+            to our <a href="http://bit.ly/bugsnewsletter">Newsletter</a>
+          </p>
+        </div>
+
       </div>
     </div>
 
-    <div class="col-12 col-lg-6">
-      <div class="gutter-padding">
-      <p>
-        Send us an <a href="mailto:bugscommunicationsteam@gmail.com">Email</a>,
-        like our <a href="https://www.facebook.com/bugsnyu/">Facebook page</a>, or subscribe
-        to our <a href="http://bit.ly/bugsnewsletter">Newsletter</a>
-      </p>
-      </div>
-
-    </div>
   </div>
-
-</div>
 </div>


### PR DESCRIPTION
**PR Type:** Bug fix
**Related #'s:**
<!-- Issues, PR's, etc. that are related to this one, comma-separated -->

<!-- Short summary -->

## Description
Add a valid facebook link. (The whole html file changed because indentations from saving with prettify)
page link: http://yuchenliu.me/bugs-nyu.github.io/
## Motivation and Context
The facebook link on the home page under "Contact Us" doesn't work.

## Screenshots (If applicable)
<!-- ![alt-text](https://url.to.image) -->
![image](https://user-images.githubusercontent.com/43976449/80898732-b3b55580-8cbb-11ea-989e-6eff48cb94e7.png)

## Checklist:
- [X] My code follows the [code style of this project][code-style]
- [X] I have read the [**CONTRIBUTING** document][contributing]

[contributing]: https://github.com/BUGS-NYU/bugs-nyu.github.io/blob/master/.github/CONTRIBUTING.md
[code-style]: https://github.com/BUGS-NYU/bugs-nyu.github.io/tree/master/docs/STYLE_GUIDE.md
