### PR TITLE
Calendar navbar fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,10 +12,10 @@ markdown: kramdown
 # Edit this if you'd like to check out the site on your own fork
 baseurl: "" # the subpath of your site, e.g. /blog
 calendar_embed:
-  xs: "https://calendar.google.com/calendar/embed?height=400&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0&amp;showNav=0&amp;mode=AGENDA"
-  sm: "https://calendar.google.com/calendar/embed?height=500&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0&amp;showNav=0&amp;mode=AGENDA"
-  md: "https://calendar.google.com/calendar/embed?height=500&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0&amp;showNav=0"
-  lg: "https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0&amp;showNav=0"
+  xs: "https://calendar.google.com/calendar/embed?height=400&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0&amp;mode=AGENDA"
+  sm: "https://calendar.google.com/calendar/embed?height=500&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0&amp;mode=AGENDA"
+  md: "https://calendar.google.com/calendar/embed?height=500&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0"
+  lg: "https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23f2f2f2&amp;ctz=America%2FNew_York&amp;src=MXJnMXZhOGhpamttNzMydGE0ajQ0bGJjaDRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%239E69AF&amp;showTitle=0&amp;showPrint=0&amp;showCalendars=0&amp;showTabs=0&amp;showDate=0"
 
 future: true
 

--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,8 @@ description: >-
   NYU BUGS is the open source club at NYU. We promote open source by engaging students
   through collaborative projects, hosting industry professions, and running open
   source workshops.
-url: "https://bugs-nyu.github.io"
-repository_url: https://github.com/BUGS-NYU/bugs-nyu.github.io
+url: "https://sntdrr.github.io/bugs-nyu.github.io/"
+repository_url: https://sntdrr.github.io/bugs-nyu.github.io/
 org_url: https://github.com/BUGS-NYU/
 markdown: kramdown
 

--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,8 @@ description: >-
   NYU BUGS is the open source club at NYU. We promote open source by engaging students
   through collaborative projects, hosting industry professions, and running open
   source workshops.
-url: "https://sntdrr.github.io/bugs-nyu.github.io/"
-repository_url: https://sntdrr.github.io/bugs-nyu.github.io/
+url: "https://bugs-nyu.github.io"
+repository_url: https://github.com/BUGS-NYU/bugs-nyu.github.io
 org_url: https://github.com/BUGS-NYU/
 markdown: kramdown
 

--- a/_contributors/sdarre.md
+++ b/_contributors/sdarre.md
@@ -1,5 +1,5 @@
 ---
 name: Santiago Darre # Name of person
-type: alum # Can be one of [ eboard, alum, founder, mentor ]
+type: member # Can be one of [ eboard, alum, founder, mentor ]
 ---
 I'm a computer science student at NYU interested in open source software development and cybersecurity.

--- a/_contributors/sdarre.md
+++ b/_contributors/sdarre.md
@@ -1,0 +1,5 @@
+---
+name: Santiago Darre # Name of person
+type: alum # Can be one of [ eboard, alum, founder, mentor ]
+---
+I'm a computer science student at NYU interested in open source software development and cybersecurity.


### PR DESCRIPTION
**PR Type:**
Bug fix
**Related #'s:**
Issue #148

<!-- Short summary -->

## Description
Fixed the issue where navigation buttons weren't appearing for the events calendar. (also added myself to contributors folder)

## Motivation and Context
The lack of a navbar meant that users would only be able to see events in the current month.

## Screenshots (If applicable)
![alt-text](https://user-images.githubusercontent.com/56235497/82167045-fd9c5f00-98a9-11ea-8ba1-8bd79475a5f9.png) 

## Checklist:
- [x] My code follows the [code style of this project][code-style]
- [x] I have read the [**CONTRIBUTING** document][contributing]

[contributing]: https://github.com/BUGS-NYU/bugs-nyu.github.io/blob/master/.github/CONTRIBUTING.md
[code-style]: https://github.com/BUGS-NYU/bugs-nyu.github.io/tree/master/docs/STYLE_GUIDE.md
